### PR TITLE
Change the "l" in "locate" to "L" / "Locate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Send an SMS to the device you want to locate in order to retrieve information ab
 **Options**
 Option | Explaination | Required permission
 -------|:------------|--------------------|
-locate | Will return the most accurate set of coordinates possible and a link to them pinpointed to OpenStreetMap | Location
+Locate | Will return the most accurate set of coordinates possible and a link to them pinpointed to OpenStreetMap | Location
 cellinfo | Will return a set of uniquely identifiable information about cell towers near the phone. You can then put this information on [OpenCellId][1] to individuate the smartphone's approximate location | Location
 battery | Will return battery infos | None |
 lock | Will  lock down the smartphone | Device Administrator |


### PR DESCRIPTION
I assumed all the commands were in lowercase, however, locate is actually Locate